### PR TITLE
fix undefined variable notice

### DIFF
--- a/app/code/community/Inchoo/Facebook/Model/Client.php
+++ b/app/code/community/Inchoo/Facebook/Model/Client.php
@@ -65,7 +65,7 @@ class Inchoo_Facebook_Model_Client
 		if ($path[0] != '/') {
 			$path = '/'.$path;
 		}
-		$url .= self::FACEBOOK_GRAPH_URI.$path;
+		$url = self::FACEBOOK_GRAPH_URI.$path;
 
 		$params['method'] = 'GET'; //??
 		


### PR DESCRIPTION
On /facebook/customer_account/connect/ getting the following error:

Notice: Undefined variable: url  in /var/www/.modman/Inchoo_Facebook/app/code/community/Inchoo/Facebook/Model/Client.php on line 68
#0 /var/www/.modman/Inchoo_Facebook/app/code/community/Inchoo/Facebook/Model/Client.php(68): mageCoreErrorHandler(8, 'Undefined varia...', '/var/www/.modma...', 68, Array)
#1 [internal function]: Inchoo_Facebook_Model_Client->graph('/me')
#2 /var/www/.modman/Inchoo_Facebook/app/code/community/Inchoo/Facebook/Model/Client.php(59): call_user_func_array(Array, Array)
#3 /var/www/.modman/Inchoo_Facebook/app/code/community/Inchoo/Facebook/controllers/Customer/AccountController.php(84): Inchoo_Facebook_Model_Client->call('/me')
#4 /var/www/app/code/core/Mage/Core/Controller/Varien/Action.php(420): Inchoo_Facebook_Customer_AccountController->connectAction()
#5 /var/www/app/code/core/Mage/Core/Controller/Varien/Router/Standard.php(253): Mage_Core_Controller_Varien_Action->dispatch('connect')
#6 /var/www/app/code/core/Mage/Core/Controller/Varien/Front.php(176): Mage_Core_Controller_Varien_Router_Standard->match(Object(Mage_Core_Controller_Request_Http))
#7 /var/www/app/code/core/Mage/Core/Model/App.php(340): Mage_Core_Controller_Varien_Front->dispatch()
#8 /var/www/app/Mage.php(627): Mage_Core_Model_App->run(Array)
#9 /var/www/index.php(80): Mage::run('', 'store')
#10 {main}
