### PR TITLE
Updated cookie to be set via Magento core model rather than Javascript.

### DIFF
--- a/app/design/frontend/default/default/template/inchoo/facebook/init.phtml
+++ b/app/design/frontend/default/default/template/inchoo/facebook/init.phtml
@@ -37,7 +37,7 @@ document.observe('click', function(e){
 		try{
 			FB.login(function(response){
 				if(response.status=='connected') {
-					Mage.Cookies.set('fb-referer', '<?php echo $this->getUrlBase64('*/*/*', array('_current' => true)); ?>');
+					<?php Mage::getModel('core/cookie')->set('fb-referer',$this->getUrlBase64('*/*/*', array('_current' => true)))?>
 					setLocation('<?php echo $this->getConnectUrl() ?>');
 				}
 			}, {scope: <?php echo $this->getRequiredPermissions() ?>});


### PR DESCRIPTION
This is a better way to set the cookie, also fixes bug I was facing when fb-referer cookie not being set.
