### PR TITLE
Network Path Reference Url

### DIFF
--- a/app/code/community/Inchoo/Facebook/Block/Channel.php
+++ b/app/code/community/Inchoo/Facebook/Block/Channel.php
@@ -12,6 +12,6 @@ class Inchoo_Facebook_Block_Channel extends Inchoo_Facebook_Block_Template
 {
     protected function _toHtml()
     {
-		return '<script src="'.($this->isSecure() ? 'https://' : 'http://').'connect.facebook.net/'.$this->escapeUrl($this->getData('locale') ?  $this->getData('locale') : $this->getLocale()).'/all.js"></script>';
+		return '<script src="//connect.facebook.net/'.$this->escapeUrl($this->getData('locale') ?  $this->getData('locale') : $this->getLocale()).'/all.js"></script>';
     }
 }


### PR DESCRIPTION
Remove the http/https from url. 

More inline with the current facebook api https://developers.facebook.com/docs/facebook-login/login-flow-for-web/v2.2
    ...
    js.src = "//connect.facebook.net/en_US/sdk.js";
    fjs.parentNode.insertBefore(js, fjs);
